### PR TITLE
Avoid printing a cryptic error when API auth fails

### DIFF
--- a/src/preload.sh
+++ b/src/preload.sh
@@ -103,6 +103,10 @@ function get_app_data() {
         log "Using API_KEY"
         response=$(curl "$API_HOST/v2/application($APP_ID)?\$expand=environment_variable&apikey=$API_KEY")
     fi
+    if [[ "$response" -eq "Unauthorized" ]]; then
+        log "API authorization failed"
+        exit 1
+    fi
     echo $response | jq --arg registryHost "$REGISTRY_HOST" '.d[0] |
         (.app_name) as $repoName |
         ($repoName + "/" + .commit | ascii_downcase) as $imageRepo |


### PR DESCRIPTION
As it currently is, the following is printed if API authorization fails:
```
...
Using API_TOKEN
parse error: Invalid numeric literal at line 2, column 0
Cleaning up
...
```

This is due to the response data being a literal `Unauthorized` instead of valid JSON, and `jq` subsequently failing to parse the output.

The goal here is to print more human readable output, aiding in error resolution / debugging.

~~**TODO:** Figure out a more robust way of determining auth failure and/or the type / reason of the request failure~~