### PR TITLE
Support flasher type images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker:17.06.1-ce-rc1-dind
+FROM docker:17.06.1-ce-dind
 
-RUN apk update && apk add --no-cache python3 parted btrfs-progs docker util-linux inotify-tools
+RUN apk update && apk add --no-cache python3 parted btrfs-progs docker util-linux inotify-tools sfdisk
 
 COPY ./requirements.txt /tmp/
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install --global resin-preload
     - [Custom Splash Screen](#custom-splash-screen)
 - [Module usage](#module-usage)
 - [Known Issues](#known-issues)
-    - [Flasher Images Unsupported](#flasher-images-unsupported)
+    - [Speed Issues For Flasher Images on macOS](#speed-issues-for-flasher-images-on-macos)
     - [Version Compatibility](#version-compatibility)
     - [BTRFS Support](#btrfs-support)
 
@@ -165,11 +165,10 @@ run.once('exit', (code, signal) => {
 
 ## Known Issues
 
-### Flasher Images Unsupported
+### Speed Issues For Flasher Images on macOS
 
-Currently flasher-type images – OS images that write the OS to
-internal storage devices (like an eMMC) on first boot – are currently unsupported.
-For details see [issue #37](https://github.com/resin-io/resin-preload-image-script/issues/37).
+Docker on macOS has [some speed issues with volumes](https://github.com/docker/for-mac/issues/77).
+This makes this script slow, especially with Flasher Images.
 
 ### Version Compatibility
 

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,6 +1,7 @@
 const childProcess = require('child_process')
 const path = require('path')
 const escape = require('command-join')
+const compareVersions = require('compare-versions');
 const preload = module.exports
 
 /** @const {String} Default container name */
@@ -42,6 +43,11 @@ preload.build = function( processOptions ) {
  */
 preload.run = function( options, processOptions ) {
 
+  const dockerApiVersion = childProcess.execSync(
+    "docker version --format '{{.Server.APIVersion}}'",
+    { encoding: 'utf8' }
+  ).trim()
+
   if( options == null ) {
     throw new Error( 'Missing options argument' )
   }
@@ -63,10 +69,13 @@ preload.run = function( options, processOptions ) {
   argv.push( `-e=API_KEY=${escape( options.apiKey || '' )}` )
   argv.push( `-e=REGISTRY_HOST=${escape( options.registryHost || '' )}` )
   argv.push( `-e=API_HOST=${escape( options.apiHost || '' )}` )
-
-  if( options.image ) {
-    argv.push( `-v=${escape( options.image )}:/img/resin.img` )
+  let volume = `-v=${escape( options.image )}:/img/resin.img`
+  if (compareVersions(dockerApiVersion, "1.28") >= 0) {
+    // :cached is only supported in Docker 17.04 and above
+    // It is supposed to speed up volumes on macOs
+    volume += ":cached"
   }
+  argv.push( volume )
 
   if( options.splashImage ) {
     argv.push( `-v=${escape( options.splashImage )}:/img/resin-logo.png` )

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "main": "lib/preload.js",
   "dependencies": {
-    "command-join": "^2.0.0"
+    "command-join": "^2.0.0",
+    "compare-versions": "^3.0.1"
   },
   "devDependencies": {},
   "peerDependencies": {},


### PR DESCRIPTION
This requires #65 to be merged first.
Connects to #37 

How it works:

 * look at the `deployArtifact` key in the `device-type.json` on the 1st partition of the image. If it contains "-flasher-" continue to the next steps, otherwise preload to the image as before.
 * resize the 2nd partition of the outer image (and move the partitions after) so the inner image fits
 * resize and preload the inner image (/opt/<deployArtifact stripped of "flasher-"> in the second partition of the outer image)

For resizing the 2nd partition and moving the ones after we use `sfdisk` to generate an sfdisk script of the image layout, update it and create a new image with the updated layout. Then we dd partitions from the original image to the new one, resize the ext filesystem of the 2nd partition and replace the original image with the one we just created.