### PR TITLE
Use localhost instead of 0.0.0.0 to connect to Docker on win32

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -682,9 +682,11 @@ class Preloader extends EventEmitter {
     .then((registryToken) => {
       const opts = { authconfig: { registrytoken: registryToken } }
       // Docker connection
+      // We use localhost on windows because of this bug in node < 8.10.0:
+      // https://github.com/nodejs/node/issues/14900
       const innerDockerProgress = new dockerProgress.DockerProgress({
         Promise,
-        host: '0.0.0.0',
+        host: (os.platform() === 'win32') ? 'localhost' : '0.0.0.0',
         port: this.dockerPort
       })
       const pullingProgressName = `Pulling ${this._pluralize(images.length, 'image')}`


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>

<img src="https://frontapp.com/assets/img/icons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_dhbn)