### PR TITLE
Rename Dockerfile to avoid the ResinCI/docker/build ci job

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,3 @@
+---
+docker:
+  builds: []

--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,3 +1,3 @@
 ---
 docker:
-  builds: []
+  publish: false


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>